### PR TITLE
Change config source if folder DNE

### DIFF
--- a/tools/atlasmanager
+++ b/tools/atlasmanager
@@ -3167,6 +3167,9 @@ doBackup(){
   fi
 
   # ATLAS server uses Lock-Truncate-Write-Unlock
+
+  [ ! -d $savedcfgdir ] && savedcfgdir="${saverootdir}/Config/LinuxServer"
+
   echo -ne "${NORMAL} Copying GameUserSettings.ini "
   cp -p "${savedcfgdir}/GameUserSettings.ini" "${backupdir}/GameUserSettings.ini"
   if [ ! -s "${backupdir}/GameUserSettings.ini" ]; then
@@ -3181,7 +3184,6 @@ doBackup(){
 
 
   echo -ne "${NORMAL} Copying Game.ini "
-  [ ! -d $savedcfgdir ] && savedcfgdir="${saverootdir}/Config/LinuxServer"
   cp -p "${savedcfgdir}/Game.ini" "${backupdir}/Game.ini"
   if [ ! -s "${backupdir}/Game.ini" ]; then
     sleep 2

--- a/tools/atlasmanager
+++ b/tools/atlasmanager
@@ -3177,8 +3177,8 @@ doBackup(){
   fi
 
 
-   echo -ne "${NORMAL} Copying Game.ini "
-
+  echo -ne "${NORMAL} Copying Game.ini "
+  [ ! -d $savedcfgdir ] && savedcfgdir="${saverootdir}/Config/LinuxServer"
   cp -p "${savedcfgdir}/Game.ini" "${backupdir}/Game.ini"
   if [ ! -s "${backupdir}/Game.ini" ]; then
     sleep 2


### PR DESCRIPTION
When running a Blackwood map (and possible other non-seamless servers), `savedcfgdir` results in a value like this:
`/atlas/server/ShooterGame/Saved/SavedArks/Config/LinuxServer`

This path does not exist.  The correct path should be: `/atlas/server/ShooterGame/Saved/Config/LinuxServer`, or IOW, `${saverootdir}/Config/LinuxServer`.