### PR TITLE
Check commit for branch existence

### DIFF
--- a/tools/atlasmanager
+++ b/tools/atlasmanager
@@ -78,10 +78,10 @@ doUpgradeToolsFromCommit(){
 }
 
 doUpgradeToolsFromBranch(){
-  atlasstLatestVersion=`curl -s "https://raw.githubusercontent.com/${atlasstGithubRepo}/${atlasstChannel}/.version"`
+  atlasstLatestVersion="${atlasstVersion}-${atlasstChannel}"
   atlasstLatestCommit=`curl -s "https://api.github.com/repos/${atlasstGithubRepo}/git/refs/heads/${atlasstChannel}" | sed -n 's/^ *"sha": "\(.*\)",.*/\1/p'`
 
-  if [[ "$atlasstLatestVersion" == "404: Not Found" ]]; then
+  if [[ -z $atlasstLatestCommit ]]; then
     echo "Channel '${atlasstChannel}' does not exist"
     echo
     echo "Available channels:"


### PR DESCRIPTION
Without a .version file, this should at least be safe to use.  Perhaps the .version file might be a better idea though?
Currently, if trying to use a different branch, it always says the branch DNE because .version always returns the 404 message.